### PR TITLE
Allow overriding the logger via a param

### DIFF
--- a/airfoil/lib/airfoil.rb
+++ b/airfoil/lib/airfoil.rb
@@ -12,16 +12,16 @@ require_relative "airfoil/railtie" if defined?(Rails::Railtie)
 
 module Airfoil
   class << self
-    def create_stack
+    def create_stack(logger)
       # ensure that STDOUT streams are synchronous so we don't lose logs
       $stdout.sync = true
 
       Signal.trap("TERM") do
         # We can't use the Rails logger here as the logger is not available in the trap context
-        puts "Received SIGTERM, shutting down gracefully..." # rubocop:disable Rails/Output
+        puts "Received SIGTERM, shutting down gracefully..."
       end
 
-      logger = defined?(::Rails) ? Rails.logger : Logger.new($stdout, level: (ENV["LOG_LEVEL"] || :info).to_sym)
+      logger ||= defined?(::Rails) ? Rails.logger : Logger.new($stdout, level: (ENV["LOG_LEVEL"] || :info).to_sym)
 
       ::Middleware::Builder.new { |b|
         if defined?(::Rails)


### PR DESCRIPTION
### Are there any dependencies (software or human) that need to be addressed before this PR is merged?
Nope

### What ticket(s) or other PRs does this relate to?
None currently

### What was the problem or feature?
Using this outside of Rails, sometimes you want to BYOL (bring your own logger)

### What was the solution?
Allow it to be passed into `create_stack`

- [x] Security Impact has been considered
- [x] Network Impacts have been considered

### Where does this work fall on the Good - Fast spectrum?
💨 

### Any additional work needed as a result of merging this PR (deploy steps, other PRs, etc.)?
Nope