### PR TITLE
Update datadog env var

### DIFF
--- a/airfoil/lib/airfoil/version.rb
+++ b/airfoil/lib/airfoil/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Airfoil
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end

--- a/datadog/lib/airfoil/datadog_railtie.rb
+++ b/datadog/lib/airfoil/datadog_railtie.rb
@@ -11,7 +11,7 @@ module Airfoil
         ::Datadog::Lambda.configure_apm do |c|
           c.env = ENV.fetch("SENTRY_ENVIRONMENT", Rails.env).dasherize
           # downscasing first ensures we don't attempt to snake case things that don't already have dashes
-          c.service = ENV.fetch("AWS_LAMBDA_FUNCTION_NAME", "brokersuite").downcase.underscore
+          c.service = (ENV["AWS_LAMBDA_FUNCTION_NAME"] || ENV["APP_NAME"] || "brokersuite").downcase.underscore
 
           # Set trace rate via DD_TRACE_SAMPLE_RATE
           c.tracing.enabled = true


### PR DESCRIPTION
### Are there any dependencies (software or human) that need to be addressed before this PR is merged?


### What ticket(s) or other PRs does this relate to?

Non-lambda usage

### What was the problem or feature?

Attempting to use Airfoil in AppRunner poses a problem with the current expected environment variable for Datadog.

```tf
│ Error: updating Lambda Function (CarrierSuite) configuration: operation error Lambda: UpdateFunctionConfiguration, https response error StatusCode: 400, RequestID: 4583aa4f-661d-46a8-a075-6290b7a9c711, InvalidParameterValueException: Lambda was unable to configure your environment variables because the environment variables you have provided contains reserved keys that are currently not supported for modification. Reserved keys used in this request: AWS_LAMBDA_FUNCTION_NAME
```

### What was the solution?

Allow an alternate naming convention and choose the first available match.

- [X] Security Impact has been considered (if yes please describe)
- [X] Network Impacts have been considered (if yes please describe)



### Where does this work fall on the Good - Fast spectrum?


### Any additional work needed as a result of merging this PR (deploy steps, other PRs, etc.)?
